### PR TITLE
refactor(core): change identifiers to float type

### DIFF
--- a/packages/core/src/wrapper/streamer/object/event.ts
+++ b/packages/core/src/wrapper/streamer/object/event.ts
@@ -53,7 +53,7 @@ const [onDynamicObjectMoved] = defineEvent({
 
 const [onPlayerEditDynamicObject] = defineEvent({
   name: "OnPlayerEditDynamicObject",
-  identifier: "iiiiiiiii",
+  identifier: "iiiffffff",
   defaultValue: false,
   beforeEach(
     pid: number,
@@ -82,7 +82,7 @@ const [onPlayerEditDynamicObject] = defineEvent({
 
 const [onPlayerSelectDynamicObject] = defineEvent({
   name: "OnPlayerSelectDynamicObject",
-  identifier: "iiiiii",
+  identifier: "iiifff",
   beforeEach(
     pid: number,
     oid: number,
@@ -104,7 +104,7 @@ const [onPlayerSelectDynamicObject] = defineEvent({
 
 const [onPlayerShootDynamicObject] = defineEvent({
   name: "OnPlayerShootDynamicObject",
-  identifier: "iiiiii",
+  identifier: "iiifff",
   beforeEach(
     pid: number,
     weapon: WeaponEnum,


### PR DESCRIPTION
Some identifiers are incorrectly defined as integers instead of floats.

### Output examples on `DynamicObjectEvent.onPlayerEdit` callback

Before:
```js
{
   response: 2,
   x: 1156841973, // ❌
   y: -992076659, // ❌
   z: 1096335360, // ❌
   rX: 0,
   rY: 0,
   rZ: 0
 }
 ```
 After:
 ```js
{
   response: 1,
   x: 1952.0611572265625,  // ✅
   y: -1782.4154052734375, // ✅
   z: 13.546875,           // ✅
   rX: 0,
   rY: 0,
   rZ: 0
}
```